### PR TITLE
Fix pandoc command to convert to epub

### DIFF
--- a/makefile
+++ b/makefile
@@ -20,7 +20,8 @@ postprocess:
 
 epub:
 	mkdir -p $(out)
-	pandoc --standalone --normalize --smart --to=epub --epub-metadata $(metadata) \
+	pandoc --from markdown+smart --to=epub \
+		--epub-metadata=$(metadata) \
 		--toc --output=$(out)/$(filename).epub $(out)/*.md
 
 mobi: epub


### PR DESCRIPTION
* Remove "--standalone" as this is standard for epub exports;
* Convert "--smart" into "markdown+smart" as the former is deprecated;
* Remove "--normalize" as this is standard.